### PR TITLE
Adds optional `platform` argument

### DIFF
--- a/lib/fastlane/plugin/last_fabric_version_code/actions/last_fabric_version_code_action.rb
+++ b/lib/fastlane/plugin/last_fabric_version_code/actions/last_fabric_version_code_action.rb
@@ -30,8 +30,15 @@ module Fastlane
         apps_parsed = JSON.parse(apps_response.body)
         apps_parsed.map do |app|
           if app['bundle_identifier'].casecmp(params[:app_package]).zero?
-            organization_id = app['organization_id']
-            app_id = app['id']
+            if params.has_key?(:platform)
+                if app['platform'].casecmp(params[:platform]).zero?
+                  organization_id = app['organization_id']
+                  app_id = app['id']
+                end
+            else
+              organization_id = app['organization_id']
+              app_id = app['id']
+            end
           end
         end
 


### PR DESCRIPTION
Optionally pass in a `platform` argument to try to match a platform type to the bundle ID. Since my iOS and Android apps use the same bundle identifier, this allows me to specify a project by passing `ios` or `android` for `platform`.